### PR TITLE
Frontend refactor and cleanup

### DIFF
--- a/frontend/src/components/AudioPlayer.jsx
+++ b/frontend/src/components/AudioPlayer.jsx
@@ -1,7 +1,0 @@
-import React from "react";
-
-export default function AudioPlayer({ src }) {
-  return (
-    <audio controls autoPlay src={src} className="w-96" />
-  );
-}

--- a/frontend/src/components/EditorCanvas.css
+++ b/frontend/src/components/EditorCanvas.css
@@ -150,22 +150,6 @@ body {
 }
 
 /* Generate button */
-.generate-btn {
-  background: linear-gradient(135deg, #667eea, #764ba2);
-  color: white;
-  border: none;
-  padding: 12px 28px;
-  border-radius: 8px;
-  font-weight: 700;
-  font-size: 18px;
-  box-shadow: 0 4px 12px rgba(102, 126, 234, 0.3);
-  transition: all 0.2s ease;
-  cursor: pointer;
-}
-
-.generate-btn:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 6px 20px rgba(102, 126, 234, 0.5);
 }
 
 /* Color Picker */

--- a/frontend/src/components/VinylIcon.jsx
+++ b/frontend/src/components/VinylIcon.jsx
@@ -1,0 +1,29 @@
+import React from "react";
+import "../index.css";
+
+export default function VinylIcon({ playing, onClick }) {
+  return (
+    <div className="vinyl-wrapper" onClick={onClick}>
+      <div className={`vinyl-rotator ${playing ? "spin" : ""}`}>
+        <svg viewBox="0 0 100 100" width="140" height="140">
+          <circle cx="50" cy="50" r="48" fill="#111" stroke="#000" strokeWidth="1" />
+          <circle cx="50" cy="50" r="40" fill="none" stroke="#333" strokeWidth="2" />
+          <circle cx="50" cy="50" r="30" fill="none" stroke="#222" strokeWidth="2" />
+          <circle cx="50" cy="50" r="5" fill="#000" />
+        </svg>
+        <div className="vinyl-indicator">
+          {playing ? (
+            <div className="dots">
+              <div className="dot dot-1" />
+              <div className="dot dot-2" />
+              <div className="dot" />
+            </div>
+          ) : (
+            <div className="paused" />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -401,3 +401,21 @@ html { scroll-behavior: smooth; }
   justify-content: center;
   margin: 0 auto;
 }
+.generate-btn {
+  background: linear-gradient(135deg, #667eea, #764ba2);
+  color: white;
+  border: none;
+  padding: 12px 28px;
+  border-radius: 8px;
+  font-weight: 700;
+  font-size: 18px;
+  box-shadow: 0 4px 12px rgba(102, 126, 234, 0.3);
+  transition: all 0.2s ease;
+  cursor: pointer;
+}
+
+.generate-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 20px rgba(102, 126, 234, 0.5);
+}
+


### PR DESCRIPTION
## Summary
- extract `VinylIcon` into its own component
- cleanup `App.jsx` and add `captureAndGenerate` helper
- remove unused `AudioPlayer` component
- move generate button styling to global CSS

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851b00ddbe88321b67cd9c3225aa669