### PR TITLE
Improve vinyl control discoverability

### DIFF
--- a/frontend/src/components/VinylIcon.jsx
+++ b/frontend/src/components/VinylIcon.jsx
@@ -1,9 +1,21 @@
-import React from "react";
+import React, { useState } from "react";
 import "../index.css";
 
 export default function VinylIcon({ playing, onClick }) {
+  const [hint, setHint] = useState("play");
+  const [fade, setFade] = useState(false);
+
+  const handleClick = (e) => {
+    if (hint === "play") {
+      setHint("pause");
+      setTimeout(() => setFade(true), 500);
+      setTimeout(() => setHint(null), 1500);
+    }
+    if (onClick) onClick(e);
+  };
+
   return (
-    <div className="vinyl-wrapper" onClick={onClick}>
+    <div className="vinyl-wrapper" onClick={handleClick}>
       <div className={`vinyl-rotator ${playing ? "spin" : ""}`}>
         <svg viewBox="0 0 100 100" width="140" height="140">
           <circle cx="50" cy="50" r="48" fill="#111" stroke="#000" strokeWidth="1" />
@@ -22,6 +34,20 @@ export default function VinylIcon({ playing, onClick }) {
             <div className="paused" />
           )}
         </div>
+        {hint && (
+          <div className={`vinyl-hint ${fade ? "fade" : ""}`}>
+            {hint === "play" ? (
+              <svg viewBox="0 0 64 64" width="40" height="40">
+                <polygon points="16,8 16,56 56,32" fill="rgba(255,255,255,0.8)" />
+              </svg>
+            ) : (
+              <svg viewBox="0 0 64 64" width="40" height="40">
+                <rect x="16" y="8" width="10" height="48" fill="rgba(255,255,255,0.8)" />
+                <rect x="38" y="8" width="10" height="48" fill="rgba(255,255,255,0.8)" />
+              </svg>
+            )}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -299,6 +299,20 @@ html { scroll-behavior: smooth; }
   opacity: 0.6;
 }
 
+/* --- play/pause hint overlay --- */
+.vinyl-hint {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+  opacity: 0.85;
+  transition: opacity 1s ease;
+}
+.vinyl-hint.fade {
+  opacity: 0;
+}
+
 @keyframes pulse {
   0%, 100% { transform: scale(1); opacity: 0.7; }
   50% { transform: scale(1.5); opacity: 1; }


### PR DESCRIPTION
## Summary
- show a temporary play/pause hint over the vinyl
- fade out the hint after the first interaction

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685222e7bc2c832180e6a56f925b1425