### PR TITLE
Add canvas preview and regenerate music

### DIFF
--- a/frontend/src/components/EditorCanvas.jsx
+++ b/frontend/src/components/EditorCanvas.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useEffect } from "react";
+import React, { useRef, useState, useEffect, forwardRef, useImperativeHandle } from "react";
 import "./EditorCanvas.css";
 import { Pencil, Eraser, Type, Undo2, Redo2, Trash2, Palette, Move } from "lucide-react";
 
@@ -9,7 +9,7 @@ const W = 896, H = 504, AUDIO_H = 120, MAX_HISTORY = 50;
 const MIN_FONT_SIZE = 1;
 const MAX_FONT_SIZE = 200;
 
-export default function EditorCanvas({ onSubmit, language, setLanguage }) {
+const EditorCanvas = forwardRef(function EditorCanvas({ onSubmit, language, setLanguage }, ref) {
   /* refs ----------------------------------------------------------- */
   const bgRef = useRef(null);   // background layer
   const inkRef = useRef(null);  // pen / eraser
@@ -75,6 +75,11 @@ export default function EditorCanvas({ onSubmit, language, setLanguage }) {
   const undo = () => { const h=histRef.current; if(h.idx>0) restore(h.states[--h.idx]); };
   const redo = () => { const h=histRef.current; if(h.idx<h.states.length-1) restore(h.states[++h.idx]); };
   useEffect(snapshot, []);                               // save blank initial
+
+  useImperativeHandle(ref, () => ({
+    getSnapshot: () => histRef.current.states[histRef.current.idx],
+    loadSnapshot: snap => restore(snap)
+  }));
 
   // Close any active text editing when switching tools
   useEffect(() => {
@@ -758,4 +763,6 @@ export default function EditorCanvas({ onSubmit, language, setLanguage }) {
       </div>
     </div>
   );
-}
+});
+
+export default EditorCanvas;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -503,3 +503,47 @@ html { scroll-behavior: smooth; }
   text-align: center;
 }
 
+/* --- Done stage layout --- */
+.done-container {
+  display: flex;
+  height: 100%;
+  width: 100%;
+}
+
+.done-left {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 1rem;
+  gap: 1rem;
+}
+
+.canvas-frame {
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  padding: 0.5rem;
+  cursor: pointer;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+}
+
+.prompt-box {
+  background: rgba(20,20,30,0.9);
+  backdrop-filter: blur(20px);
+  border: 1px solid rgba(255,255,255,0.15);
+  border-radius: 12px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.prompt-box textarea {
+  background: rgba(255,255,255,0.1);
+  border: none;
+  color: #fff;
+  padding: 0.5rem;
+  border-radius: 6px;
+  resize: vertical;
+}
+


### PR DESCRIPTION
## Summary
- add canvas preview on Done stage with prompt & lyric editor
- allow returning to the editor with original canvas state
- enable music regeneration via new `/regenerate` endpoint
- expose snapshot controls from `EditorCanvas`
- style new UI elements

## Testing
- `python backend/test_pipelines.py` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68526c2922b483218771ec6e275a8f50