### PR TITLE
Disable music prompt when music option is off

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -242,6 +242,10 @@ export default function App() {
   }, [stage]);
 
   async function regenerateMusic() {
+    if (!doMusic) {
+      alert('Music option not selected.');
+      return;
+    }
     if (!runFolder) return;
     setRegenLoading(true);
     setPendingMusic(true);
@@ -420,6 +424,8 @@ export default function App() {
           </div>
         )}
         <div className="prompt-box">
+          {doMusic ? (
+            <>
           <label className="prompt-field">
             <div className="prompt-label">Prompt</div>
             <textarea
@@ -538,6 +544,10 @@ export default function App() {
           >
             {regenLoading ? "Regenerating..." : "Regenerate Music"}
           </button>
+            </>
+          ) : (
+            <p style={{textAlign:'center', opacity:0.8}}>Music option not selected.</p>
+          )}
         </div>
       </div>
       <div className="app-right-container">


### PR DESCRIPTION
## Summary
- disable music regeneration prompt box when music option isn't selected
- notify user when attempting to regenerate without music option

## Testing
- `python backend/test_pipelines.py` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6854425072bc8321bfed90089bbecbe7